### PR TITLE
Fixing pygpt4all compatibility issue with latest version

### DIFF
--- a/pygpt4all_setup.py
+++ b/pygpt4all_setup.py
@@ -1,7 +1,5 @@
-from pygpt4all.models.gpt4all import GPT4All
-
-def new_text_callback(text):
-    print(text, end="")
-
+from pygpt4all import GPT4All
 model = GPT4All('./models/gpt4all-converted.bin')
-model.generate("Once upon a time, ", n_predict=55, new_text_callback=new_text_callback)
+
+for token in model.generate("Once upon a time", n_predict=55):
+    print(token, end='', flush=True)


### PR DESCRIPTION
Fixing a compatibility issue with latest (current) pygpt4all package, because `new_text_callback` was removed.